### PR TITLE
データ送信用のメッセージコンテントの修正

### DIFF
--- a/src/main/java/com/example/hl_appserver/AServerConnector.java
+++ b/src/main/java/com/example/hl_appserver/AServerConnector.java
@@ -1,9 +1,6 @@
 package com.example.hl_appserver;
 
 import com.google.gson.Gson;
-import sample.EndpointExample;
-import sample.EndpointSample;
-import sample.SampleMessage;
 
 import javax.websocket.*;
 import javax.websocket.server.ServerEndpoint;

--- a/src/main/java/com/example/hl_appserver/MessageContent.java
+++ b/src/main/java/com/example/hl_appserver/MessageContent.java
@@ -1,11 +1,19 @@
 package com.example.hl_appserver;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MessageContent{
 
 	String user_id;
 	String password;
-	String score;
-	String rule;
+	//String score;
+	int num_plays_score;
+	int num_hits_score;
+	int num_wins_score;
+	//String rule;
+	//カードおよびルールの画像ファイル(base64)格納用のリスト
+	List<String> textDataList = new ArrayList<>();
 	String error;
 
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,9 @@
 module com.example.hl_appserver {
 	requires javafx.controls;
 	requires javafx.fxml;
+	requires javax.websocket.api;
+	requires com.google.gson;
+	requires tyrus.server;
 
 
 	opens com.example.hl_appserver to javafx.fxml;


### PR DESCRIPTION
## やったこと
メッセージコンテントclassの変更
戦績を送信する際、プレイ回数、勝利数、ヒット数が必要なので追加しました。
カードとルールの送信に関しても、base64のテキストデータを送るので、同じくStringのリストを追加しました。

## やらなかったこと(できなかったこと)
 - 技術的にできなかった(どうしたらいいのかわからなかったとか)
 - 現在の状況的にできなかった(〇〇サーバーの中身が必要とか)
 - その他(例:各事情によりできなかった(しんどすぎたとか))

があれば記述してください。

## 削除したファイル・機能など
あれば記述してください。

## レビュー観点
主に見てほしい部分や動作などがあれば記述してください。重点的に確認します。

## テスト項目・動作
( ´_`)...(テスト項目になりそうなところを書いておくと最後らへんのテスト項目とかの記述が楽になるかなぁ)

## その他
補足や懸念・不安点、参考にしたサイトやほかの人にもチェックしてほしいもの、その他上の項目に書ききれなかったものがあれば記述してください。
